### PR TITLE
Add initial database schema and migration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example database connection string
+DATABASE_URL="postgresql://USER:PASSWORD@localhost:5432/clearconsent"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log*
 
 # env files
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# ClearConsent
+
+This project is a Next.js prototype for the ClearConsent platform.
+
+## Database Migrations
+
+PostgreSQL is used via [Prisma](https://www.prisma.io/). The schema
+is defined in [`prisma/schema.prisma`](prisma/schema.prisma) and the
+initial SQL migration is located under [`prisma/migrations`](prisma/migrations).
+
+### Running Migrations
+
+1. Copy `.env.example` to `.env` and update `DATABASE_URL` with your
+   PostgreSQL connection string.
+2. Install dependencies and run Prisma migrations:
+
+```bash
+pnpm install
+pnpm prisma migrate deploy
+```
+
+This will create the required tables in your database and generate
+the Prisma client.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
-    "zod": "latest"
+    "zod": "latest",
+    "@prisma/client": "^5.9.0"
   },
   "devDependencies": {
     "@types/node": "^22",
@@ -65,6 +66,7 @@
     "@types/react-dom": "^19",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "prisma": "^5.9.0"
   }
 }

--- a/prisma/migrations/0001_init/migration.sql
+++ b/prisma/migrations/0001_init/migration.sql
@@ -1,0 +1,57 @@
+CREATE TABLE "Doctor" (
+    "id" SERIAL PRIMARY KEY,
+    "email" TEXT NOT NULL UNIQUE,
+    "passwordHash" TEXT NOT NULL,
+    "firstName" TEXT NOT NULL,
+    "lastName" TEXT NOT NULL,
+    "phone" TEXT,
+    "createdAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+    "updatedAt" TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE "Patient" (
+    "id" SERIAL PRIMARY KEY,
+    "doctorId" INTEGER REFERENCES "Doctor"("id"),
+    "email" TEXT NOT NULL UNIQUE,
+    "passwordHash" TEXT NOT NULL,
+    "firstName" TEXT NOT NULL,
+    "lastName" TEXT NOT NULL,
+    "dateOfBirth" DATE,
+    "phone" TEXT,
+    "address" TEXT,
+    "city" TEXT,
+    "state" TEXT,
+    "zipCode" TEXT,
+    "createdAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+    "updatedAt" TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE "Procedure" (
+    "id" SERIAL PRIMARY KEY,
+    "doctorId" INTEGER NOT NULL REFERENCES "Doctor"("id"),
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "pdfUrl" TEXT,
+    "videoUrl" TEXT,
+    "createdAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+    "updatedAt" TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE "Assignment" (
+    "id" SERIAL PRIMARY KEY,
+    "patientId" INTEGER NOT NULL REFERENCES "Patient"("id"),
+    "procedureId" INTEGER NOT NULL REFERENCES "Procedure"("id"),
+    "status" TEXT NOT NULL DEFAULT 'SENT',
+    "startedAt" TIMESTAMP,
+    "completedAt" TIMESTAMP,
+    "createdAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+    "updatedAt" TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE "ChatMessage" (
+    "id" SERIAL PRIMARY KEY,
+    "assignmentId" INTEGER NOT NULL REFERENCES "Assignment"("id"),
+    "senderType" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,89 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Doctor {
+  id           Int          @id @default(autoincrement())
+  email        String       @unique
+  passwordHash String
+  firstName    String
+  lastName     String
+  phone        String?
+  procedures   Procedure[]
+  patients     Patient[]
+  assignments  Assignment[]
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
+}
+
+model Patient {
+  id           Int          @id @default(autoincrement())
+  doctor       Doctor?      @relation(fields: [doctorId], references: [id])
+  doctorId     Int?
+  email        String       @unique
+  passwordHash String
+  firstName    String
+  lastName     String
+  dateOfBirth  DateTime?
+  phone        String?
+  address      String?
+  city         String?
+  state        String?
+  zipCode      String?
+  assignments  Assignment[]
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
+}
+
+model Procedure {
+  id           Int          @id @default(autoincrement())
+  doctor       Doctor       @relation(fields: [doctorId], references: [id])
+  doctorId     Int
+  title        String
+  description  String
+  pdfUrl       String?
+  videoUrl     String?
+  assignments  Assignment[]
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
+}
+
+model Assignment {
+  id           Int             @id @default(autoincrement())
+  patient      Patient         @relation(fields: [patientId], references: [id])
+  patientId    Int
+  procedure    Procedure       @relation(fields: [procedureId], references: [id])
+  procedureId  Int
+  status       AssignmentStatus @default(SENT)
+  startedAt    DateTime?
+  completedAt  DateTime?
+  chatMessages ChatMessage[]
+  createdAt    DateTime        @default(now())
+  updatedAt    DateTime        @updatedAt
+}
+
+model ChatMessage {
+  id           Int        @id @default(autoincrement())
+  assignment   Assignment @relation(fields: [assignmentId], references: [id])
+  assignmentId Int
+  senderType   SenderType
+  content      String
+  createdAt    DateTime   @default(now())
+}
+
+enum AssignmentStatus {
+  SENT
+  VIEWED
+  IN_PROGRESS
+  COMPLETED
+}
+
+enum SenderType {
+  DOCTOR
+  PATIENT
+}


### PR DESCRIPTION
## Summary
- set up Prisma with PostgreSQL
- add initial schema and SQL migration
- add sample `.env.example` and document migration steps
- allow committing `.env.example` via `.gitignore`

## Testing
- `pnpm lint` *(fails: next not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced initial database schema supporting doctors, patients, procedures, assignments, and chat messages.
  - Added support for tracking assignment status and message sender types.
  - Provided a template environment configuration file to assist with setup.

- **Documentation**
  - Added a README with setup instructions and database migration guidance.

- **Chores**
  - Updated dependencies to include Prisma and its client.
  - Adjusted version control settings to include the example environment file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->